### PR TITLE
[Feature][Remote] 이메일, 아이디, 닉네임 중복확인 기능을 서버와 연결합니다.

### DIFF
--- a/core/data/src/main/java/com/saeongjima/data/api/SignUpService.kt
+++ b/core/data/src/main/java/com/saeongjima/data/api/SignUpService.kt
@@ -1,0 +1,12 @@
+package com.saeongjima.data.api
+
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface SignUpService {
+    @GET("/api/user/check-email")
+    suspend fun validateEmail(
+        @Query("email")
+        email: String
+    ): Result<Boolean>
+}

--- a/core/data/src/main/java/com/saeongjima/data/api/SignUpService.kt
+++ b/core/data/src/main/java/com/saeongjima/data/api/SignUpService.kt
@@ -9,4 +9,10 @@ interface SignUpService {
         @Query("email")
         email: String
     ): Result<Boolean>
+
+    @GET("/api/user/check-username")
+    suspend fun validateId(
+        @Query("username")
+        username: String
+    ): Result<Boolean>
 }

--- a/core/data/src/main/java/com/saeongjima/data/api/SignUpService.kt
+++ b/core/data/src/main/java/com/saeongjima/data/api/SignUpService.kt
@@ -15,4 +15,10 @@ interface SignUpService {
         @Query("username")
         username: String
     ): Result<Boolean>
+
+    @GET("/api/user/check-nickname")
+    suspend fun validateNickname(
+        @Query("nickname")
+        nickname: String
+    ): Result<Boolean>
 }

--- a/core/data/src/main/java/com/saeongjima/data/di/DataModule.kt
+++ b/core/data/src/main/java/com/saeongjima/data/di/DataModule.kt
@@ -1,7 +1,9 @@
 package com.saeongjima.data.di
 
 import com.saeongjima.data.repository.DefaultSignInRepository
+import com.saeongjima.data.repository.DefaultSignUpRepository
 import com.saeongjima.data.repository.SignInRepository
+import com.saeongjima.data.repository.SignUpRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -14,4 +16,9 @@ abstract class DataModule {
     abstract fun bindsSignInRepository(
         repository: DefaultSignInRepository,
     ): SignInRepository
+
+    @Binds
+    abstract fun bindsSignUpRepository(
+        repository: DefaultSignUpRepository,
+    ): SignUpRepository
 }

--- a/core/data/src/main/java/com/saeongjima/data/di/NetworkServiceModule.kt
+++ b/core/data/src/main/java/com/saeongjima/data/di/NetworkServiceModule.kt
@@ -1,6 +1,8 @@
 package com.saeongjima.data.di
 
 import com.saeongjima.data.api.SignInService
+import com.saeongjima.data.api.SignUpService
+import com.saeongjima.data.token.PublicRetrofit
 import com.saeongjima.data.token.SignInRetrofit
 import dagger.Module
 import dagger.Provides
@@ -17,4 +19,10 @@ object NetworkServiceModule {
     fun providesSignInService(
         @SignInRetrofit retrofit: Retrofit,
     ): SignInService = retrofit.create(SignInService::class.java)
+
+    @Singleton
+    @Provides
+    fun providesSignUpService(
+        @PublicRetrofit retrofit: Retrofit,
+    ): SignUpService = retrofit.create(SignUpService::class.java)
 }

--- a/core/data/src/main/java/com/saeongjima/data/repository/DefaultSignUpRepository.kt
+++ b/core/data/src/main/java/com/saeongjima/data/repository/DefaultSignUpRepository.kt
@@ -2,6 +2,7 @@ package com.saeongjima.data.repository
 
 import com.saeongjima.data.api.SignUpService
 import com.saeongjima.model.account.Email
+import com.saeongjima.model.account.Id
 import javax.inject.Inject
 
 class DefaultSignUpRepository @Inject constructor(
@@ -9,5 +10,9 @@ class DefaultSignUpRepository @Inject constructor(
 ) : SignUpRepository {
     override suspend fun validateEmail(email: Email): Result<Boolean> {
         return signUpService.validateEmail(email.value)
+    }
+
+    override suspend fun validateId(id: Id): Result<Boolean> {
+        return signUpService.validateId(id.value)
     }
 }

--- a/core/data/src/main/java/com/saeongjima/data/repository/DefaultSignUpRepository.kt
+++ b/core/data/src/main/java/com/saeongjima/data/repository/DefaultSignUpRepository.kt
@@ -1,0 +1,13 @@
+package com.saeongjima.data.repository
+
+import com.saeongjima.data.api.SignUpService
+import com.saeongjima.model.account.Email
+import javax.inject.Inject
+
+class DefaultSignUpRepository @Inject constructor(
+    private val signUpService: SignUpService
+) : SignUpRepository {
+    override suspend fun validateEmail(email: Email): Result<Boolean> {
+        return signUpService.validateEmail(email.value)
+    }
+}

--- a/core/data/src/main/java/com/saeongjima/data/repository/DefaultSignUpRepository.kt
+++ b/core/data/src/main/java/com/saeongjima/data/repository/DefaultSignUpRepository.kt
@@ -3,6 +3,7 @@ package com.saeongjima.data.repository
 import com.saeongjima.data.api.SignUpService
 import com.saeongjima.model.account.Email
 import com.saeongjima.model.account.Id
+import com.saeongjima.model.account.Nickname
 import javax.inject.Inject
 
 class DefaultSignUpRepository @Inject constructor(
@@ -14,5 +15,9 @@ class DefaultSignUpRepository @Inject constructor(
 
     override suspend fun validateId(id: Id): Result<Boolean> {
         return signUpService.validateId(id.value)
+    }
+
+    override suspend fun validateNickname(nickname: Nickname): Result<Boolean> {
+        return signUpService.validateNickname(nickname.value)
     }
 }

--- a/core/data/src/main/java/com/saeongjima/data/repository/SignUpRepository.kt
+++ b/core/data/src/main/java/com/saeongjima/data/repository/SignUpRepository.kt
@@ -1,7 +1,9 @@
 package com.saeongjima.data.repository
 
 import com.saeongjima.model.account.Email
+import com.saeongjima.model.account.Id
 
 interface SignUpRepository {
     suspend fun validateEmail(email: Email): Result<Boolean>
+    suspend fun validateId(id: Id): Result<Boolean>
 }

--- a/core/data/src/main/java/com/saeongjima/data/repository/SignUpRepository.kt
+++ b/core/data/src/main/java/com/saeongjima/data/repository/SignUpRepository.kt
@@ -2,8 +2,10 @@ package com.saeongjima.data.repository
 
 import com.saeongjima.model.account.Email
 import com.saeongjima.model.account.Id
+import com.saeongjima.model.account.Nickname
 
 interface SignUpRepository {
     suspend fun validateEmail(email: Email): Result<Boolean>
     suspend fun validateId(id: Id): Result<Boolean>
+    suspend fun validateNickname(nickname: Nickname): Result<Boolean>
 }

--- a/core/data/src/main/java/com/saeongjima/data/repository/SignUpRepository.kt
+++ b/core/data/src/main/java/com/saeongjima/data/repository/SignUpRepository.kt
@@ -1,0 +1,7 @@
+package com.saeongjima.data.repository
+
+import com.saeongjima.model.account.Email
+
+interface SignUpRepository {
+    suspend fun validateEmail(email: Email): Result<Boolean>
+}

--- a/core/designsystem/src/main/java/com/saeongjima/designsystem/component/dialog/LoadingDialog.kt
+++ b/core/designsystem/src/main/java/com/saeongjima/designsystem/component/dialog/LoadingDialog.kt
@@ -1,0 +1,49 @@
+package com.saeongjima.designsystem.component.dialog
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.DialogWindowProvider
+import com.saeongjima.designsystem.R
+import com.saeongjima.designsystem.theme.Black200
+import com.saeongjima.designsystem.theme.PointColor1
+
+@Composable
+fun LoadingDialog(
+    onDismissRequest: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        (LocalView.current.parent as DialogWindowProvider).window.setDimAmount(0.8f)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    horizontal = dimensionResource(id = R.dimen.layout_default_padding),
+                    vertical = 12.dp
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(56.dp),
+                color = PointColor1,
+                strokeWidth = 6.dp,
+                trackColor = Black200,
+                strokeCap = StrokeCap.Round,
+            )
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/saeongjima/designsystem/component/dialog/LoadingDialog.kt
+++ b/core/designsystem/src/main/java/com/saeongjima/designsystem/component/dialog/LoadingDialog.kt
@@ -21,7 +21,7 @@ import com.saeongjima.designsystem.theme.PointColor1
 
 @Composable
 fun LoadingDialog(
-    onDismissRequest: () -> Unit,
+    onDismissRequest: () -> Unit = {},
 ) {
     Dialog(
         onDismissRequest = onDismissRequest,

--- a/core/domain/src/main/java/com/saeongjima/domain/usecase/ValidateEmailUseCase.kt
+++ b/core/domain/src/main/java/com/saeongjima/domain/usecase/ValidateEmailUseCase.kt
@@ -1,0 +1,13 @@
+package com.saeongjima.domain.usecase
+
+import com.saeongjima.data.repository.SignUpRepository
+import com.saeongjima.model.account.Email
+import javax.inject.Inject
+
+class ValidateEmailUseCase @Inject constructor(
+    private val signUpRepository: SignUpRepository
+) {
+    suspend operator fun invoke(email: Email): Result<Boolean> {
+        return signUpRepository.validateEmail(email)
+    }
+}

--- a/core/domain/src/main/java/com/saeongjima/domain/usecase/ValidateIdUseCase.kt
+++ b/core/domain/src/main/java/com/saeongjima/domain/usecase/ValidateIdUseCase.kt
@@ -1,0 +1,13 @@
+package com.saeongjima.domain.usecase
+
+import com.saeongjima.data.repository.SignUpRepository
+import com.saeongjima.model.account.Id
+import javax.inject.Inject
+
+class ValidateIdUseCase @Inject constructor(
+    private val signUpRepository: SignUpRepository
+) {
+    suspend operator fun invoke(id: Id): Result<Boolean> {
+        return signUpRepository.validateId(id)
+    }
+}

--- a/core/domain/src/main/java/com/saeongjima/domain/usecase/ValidateNicknameUseCase.kt
+++ b/core/domain/src/main/java/com/saeongjima/domain/usecase/ValidateNicknameUseCase.kt
@@ -1,0 +1,13 @@
+package com.saeongjima.domain.usecase
+
+import com.saeongjima.data.repository.SignUpRepository
+import com.saeongjima.model.account.Nickname
+import javax.inject.Inject
+
+class ValidateNicknameUseCase @Inject constructor(
+    private val signupRepository: SignUpRepository,
+) {
+    suspend operator fun invoke(nickname: Nickname): Result<Boolean> {
+        return signupRepository.validateNickname(nickname)
+    }
+}

--- a/core/model/src/main/java/com/saeongjima/model/account/Email.kt
+++ b/core/model/src/main/java/com/saeongjima/model/account/Email.kt
@@ -1,0 +1,4 @@
+package com.saeongjima.model.account
+
+@JvmInline
+value class Email(val value: String)

--- a/feature/onboading/src/main/java/com/saeongjima/signup/personalinformation/PersonalInformationScreen.kt
+++ b/feature/onboading/src/main/java/com/saeongjima/signup/personalinformation/PersonalInformationScreen.kt
@@ -81,7 +81,7 @@ internal fun PersonalInformationScreen(
     onNextButtonClick: (PersonalInformationUiState) -> Unit,
 ) {
     if (uiState.isLoading) {
-        LoadingDialog(onDismissRequest = { /*TODO*/ })
+        LoadingDialog()
     }
 
     Column(

--- a/feature/onboading/src/main/java/com/saeongjima/signup/personalinformation/PersonalInformationScreen.kt
+++ b/feature/onboading/src/main/java/com/saeongjima/signup/personalinformation/PersonalInformationScreen.kt
@@ -131,7 +131,7 @@ internal fun PersonalInformationScreen(
                 .padding(top = 32.dp),
         ) {
             DanjamDuplicationCheckButtonTextField(
-                value = uiState.email,
+                value = uiState.email.value,
                 onValueChange = onEmailChanged,
                 hintText = stringResource(personal_information_email_input_box_hint),
                 isError = uiState.isValidEmail == DuplicateState.Duplicated,

--- a/feature/onboading/src/main/java/com/saeongjima/signup/personalinformation/PersonalInformationScreen.kt
+++ b/feature/onboading/src/main/java/com/saeongjima/signup/personalinformation/PersonalInformationScreen.kt
@@ -29,6 +29,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.saeongjima.designsystem.R.string.main_button_text_next
 import com.saeongjima.designsystem.component.button.MainButton
+import com.saeongjima.designsystem.component.dialog.LoadingDialog
 import com.saeongjima.designsystem.component.textfield.DanjamBasicTextField
 import com.saeongjima.designsystem.component.textfield.DanjamDuplicationCheckButtonTextField
 import com.saeongjima.designsystem.component.textfield.InputBox
@@ -79,6 +80,10 @@ internal fun PersonalInformationScreen(
     onEmailValidateButtonClick: () -> Unit,
     onNextButtonClick: (PersonalInformationUiState) -> Unit,
 ) {
+    if (uiState.isLoading) {
+        LoadingDialog(onDismissRequest = { /*TODO*/ })
+    }
+
     Column(
         modifier = modifier,
     ) {

--- a/feature/onboading/src/main/java/com/saeongjima/signup/personalinformation/PersonalInformationUiState.kt
+++ b/feature/onboading/src/main/java/com/saeongjima/signup/personalinformation/PersonalInformationUiState.kt
@@ -4,6 +4,7 @@ import com.saeongjima.model.DuplicateState
 import com.saeongjima.model.account.Email
 
 data class PersonalInformationUiState(
+    val isLoading: Boolean = false,
     val name: String = "",
     val isMale: Boolean = true,
     val birthDay: String = "",

--- a/feature/onboading/src/main/java/com/saeongjima/signup/personalinformation/PersonalInformationUiState.kt
+++ b/feature/onboading/src/main/java/com/saeongjima/signup/personalinformation/PersonalInformationUiState.kt
@@ -1,18 +1,19 @@
 package com.saeongjima.signup.personalinformation
 
 import com.saeongjima.model.DuplicateState
+import com.saeongjima.model.account.Email
 
 data class PersonalInformationUiState(
     val name: String = "",
     val isMale: Boolean = true,
     val birthDay: String = "",
-    val email: String = "",
+    val email: Email = Email(""),
     val isValidEmail: DuplicateState = DuplicateState.NotChecked,
 ) {
     fun hasMetAllConditions(): Boolean {
         return name.isNotBlank() &&
                 birthDay.isNotBlank() &&
-                email.isNotBlank() &&
+                email.value.isNotBlank() &&
                 isValidEmail == DuplicateState.NotDuplicated
     }
 }

--- a/feature/onboading/src/main/java/com/saeongjima/signup/personalinformation/PersonalInformationViewModel.kt
+++ b/feature/onboading/src/main/java/com/saeongjima/signup/personalinformation/PersonalInformationViewModel.kt
@@ -51,11 +51,12 @@ class PersonalInformationViewModel @Inject constructor(
 
     fun checkValidationEmail() {
         viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
             validateEmailUseCase(email = uiState.value.email)
                 .onSuccess { isValid ->
                     _uiState.update {
                         it.copy(
-                            email = Email(""),
+                            email = if (isValid) it.email else Email(""),
                             isValidEmail = if (isValid) DuplicateState.NotDuplicated else DuplicateState.Duplicated
                         )
                     }
@@ -63,6 +64,7 @@ class PersonalInformationViewModel @Inject constructor(
                 .onFailure {
                     // TODO: 오류 처리 어떻게 할지 합의 후 변경
                 }
+            _uiState.update { it.copy(isLoading = false) }
         }
     }
 }

--- a/feature/onboading/src/main/java/com/saeongjima/signup/personalinformation/PersonalInformationViewModel.kt
+++ b/feature/onboading/src/main/java/com/saeongjima/signup/personalinformation/PersonalInformationViewModel.kt
@@ -1,16 +1,22 @@
 package com.saeongjima.signup.personalinformation
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.saeongjima.domain.usecase.ValidateEmailUseCase
 import com.saeongjima.model.DuplicateState
+import com.saeongjima.model.account.Email
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class PersonalInformationViewModel @Inject constructor() : ViewModel() {
+class PersonalInformationViewModel @Inject constructor(
+    private val validateEmailUseCase: ValidateEmailUseCase
+) : ViewModel() {
 
     private val _uiState: MutableStateFlow<PersonalInformationUiState> =
         MutableStateFlow(PersonalInformationUiState())
@@ -37,18 +43,26 @@ class PersonalInformationViewModel @Inject constructor() : ViewModel() {
     fun updateEmail(value: String) {
         _uiState.update {
             it.copy(
-                email = value,
+                email = Email(value),
                 isValidEmail = DuplicateState.NotChecked
             )
         }
     }
 
-    // TODO: 서버 연결시 로직 변경
     fun checkValidationEmail() {
-        _uiState.update {
-            it.copy(
-                isValidEmail = DuplicateState.NotDuplicated
-            )
+        viewModelScope.launch {
+            validateEmailUseCase(email = uiState.value.email)
+                .onSuccess { isValid ->
+                    _uiState.update {
+                        it.copy(
+                            email = Email(""),
+                            isValidEmail = if (isValid) DuplicateState.NotDuplicated else DuplicateState.Duplicated
+                        )
+                    }
+                }
+                .onFailure {
+                    // TODO: 오류 처리 어떻게 할지 합의 후 변경
+                }
         }
     }
 }

--- a/feature/onboading/src/main/java/com/saeongjima/signup/signininformation/SignInInformationScreen.kt
+++ b/feature/onboading/src/main/java/com/saeongjima/signup/signininformation/SignInInformationScreen.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.saeongjima.designsystem.R
 import com.saeongjima.designsystem.R.string.main_button_text_next
 import com.saeongjima.designsystem.component.button.MainButton
+import com.saeongjima.designsystem.component.dialog.LoadingDialog
 import com.saeongjima.designsystem.component.textfield.DanjamDuplicationCheckButtonTextField
 import com.saeongjima.designsystem.component.textfield.InputBox
 import com.saeongjima.designsystem.component.textfield.SecureTextField
@@ -95,6 +96,10 @@ fun SignInInformationScreen(
     onNextButtonClick: (SignInInformationUiState) -> Unit,
 ) {
     val scrollState: ScrollState = rememberScrollState()
+
+    if (uiState.isLoading) {
+        LoadingDialog()
+    }
 
     Column(modifier = modifier) {
 

--- a/feature/onboading/src/main/java/com/saeongjima/signup/signininformation/SignInInformationUiState.kt
+++ b/feature/onboading/src/main/java/com/saeongjima/signup/signininformation/SignInInformationUiState.kt
@@ -6,6 +6,7 @@ import com.saeongjima.model.account.Nickname
 import com.saeongjima.model.account.Password
 
 data class SignInInformationUiState(
+    val isLoading: Boolean = false,
     val id: Id = Id(""),
     val isIdDuplication: DuplicateState = DuplicateState.NotChecked,
     val nickname: Nickname = Nickname(""),

--- a/feature/onboading/src/main/java/com/saeongjima/signup/signininformation/SignInInformationViewModel.kt
+++ b/feature/onboading/src/main/java/com/saeongjima/signup/signininformation/SignInInformationViewModel.kt
@@ -3,6 +3,7 @@ package com.saeongjima.signup.signininformation
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.saeongjima.domain.usecase.ValidateIdUseCase
+import com.saeongjima.domain.usecase.ValidateNicknameUseCase
 import com.saeongjima.model.DuplicateState
 import com.saeongjima.model.account.Id
 import com.saeongjima.model.account.Nickname
@@ -17,7 +18,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SignInInformationViewModel @Inject constructor(
-    private val validateIdUseCase: ValidateIdUseCase
+    private val validateIdUseCase: ValidateIdUseCase,
+    private val validateNicknameUseCase: ValidateNicknameUseCase,
 ) : ViewModel() {
 
     private val _signInInformationUiState: MutableStateFlow<SignInInformationUiState> =
@@ -76,9 +78,20 @@ class SignInInformationViewModel @Inject constructor(
 
     fun checkNicknameDuplication() {
         viewModelScope.launch {
-            _signInInformationUiState.update {
-                it.copy(isNicknameDuplication = DuplicateState.NotDuplicated) // TODO: 서버 통신 연결 시 변경)
-            }
+            _signInInformationUiState.update { it.copy(isLoading = true) }
+            validateNicknameUseCase(_signInInformationUiState.value.nickname)
+                .onSuccess { isValid ->
+                    _signInInformationUiState.update {
+                        it.copy(
+                            nickname = if (isValid) it.nickname else Nickname(""),
+                            isNicknameDuplication = if (isValid) DuplicateState.NotDuplicated else DuplicateState.Duplicated
+                        )
+                    }
+                }
+                .onFailure {
+                    // TODO: 오류 처리 어떻게 할지 합의 후 변경
+                }
+            _signInInformationUiState.update { it.copy(isLoading = false) }
         }
     }
 }


### PR DESCRIPTION
## AS-IS
기존 임시로 적용 시켜주었던 이메일, 아이디, 닉네임 중복확인 기능을 

## TO-BE
서버와 연결하여 상호작용 할 수 있게 변경하였습니다.

## KEY-POINT
서버와 연결하는 동안 화면에 표시될 로딩 다이얼로그도 같이 구현 했습니다.